### PR TITLE
Add FarolCovid cities & states

### DIFF
--- a/src/loader/endpoints/aux/farol_config.yaml
+++ b/src/loader/endpoints/aux/farol_config.yaml
@@ -1,0 +1,88 @@
+simulacovid:
+    columns: [
+        "city_id",
+        "city_name",
+        "state_id",
+        "state_name",
+        "population",
+        "number_beds",
+        "number_ventilators",
+        "confirmed_cases",
+        "active_cases",
+        "deaths",
+        "notification_rate",
+        "state_notification_rate"
+    ]   
+    state_agg: {
+            "population": sum,
+            "confirmed_cases": sum,
+            "active_cases": sum,
+            "deaths": sum,
+            "state_notification_rate": max,
+            "number_beds": sum,
+            "number_ventilators": sum
+    }
+    
+resources:
+    available_proportion: 0.5
+        
+rules:
+    rt_classification:
+        column_name: 'rt_10days_ago_most_likely'
+        cuts: [0, 1, 1.2, 5.001]
+        categories: ['bom', 'insatisfatorio', 'ruim'] # [1, 0, -1]
+
+    rt_growth:
+        column_name: "rt_ratio_week_avg"
+        cuts: [0, 0.9, 1.1, 1000]
+        categories: ['melhorando', 'estabilizando', 'piorando'] # [1, 0, -1]
+
+    dday_classification:
+        column_name: 'dday_beds_best'
+        cuts: [0, 30, 60, 91.001]
+        categories: ['ruim', 'insatisfatorio', 'bom'] # [-1, 0, 1]
+
+    subnotification_classification:
+        column_name: 'subnotification_rate'
+        cuts: [0, 0.5, 0.7, 1.001]
+        categories: ['bom', 'insatisfatorio', 'ruim']  # [1, 0, -1]
+
+    inloco_growth:
+        column_name: 'inloco_ratio_week_avgs'
+        cuts: [0, 0.9, 1.1, 1000]
+        categories: ['piorando', 'estabilizando', 'melhorando'] # [-1, 0, 1]
+        
+alerts:
+    alto: 
+        conditions: {
+            rt_classification: "ruim",
+            rt_growth: "piorando",
+            dday_classification: "ruim",
+            subnotification_classification: "ruim"
+           }
+        how: "any"
+    medio: 
+        conditions: {
+            rt_classification: "insatisfatorio",
+            rt_growth: "melhorando|estabilizando",
+            dday_classification: "bom|insatisfatorio",
+            subnotification_classification: "bom|insatisfatorio"  
+        }
+        how: "all"
+    medio2: 
+        conditions: {
+            rt_classification: "bom|insatisfatorio",
+            rt_growth: "melhorando|estabilizando",
+            dday_classification: "bom|insatisfatorio",
+            subnotification_classification: "insatisfatorio"  
+        }
+        how: "all"
+    baixo:
+        conditions: {
+            rt_classification: "bom",
+            rt_growth: "melhorando|estabilizando",
+            dday_classification: "bom|insatisfatorio",
+            subnotification_classification: "bom"            
+        }
+        how: "all"
+

--- a/src/loader/endpoints/get_cases.py
+++ b/src/loader/endpoints/get_cases.py
@@ -87,6 +87,7 @@ def _correct_cumulative_cases(df):
 
     # Corrije acumulado para o valor máximo até a data
     df["confirmed_cases"] = df.groupby("city_id").cummax()["confirmed_cases"]
+    df["deaths"] = df.groupby("city_id").cummax()["deaths"]
 
     # Recalcula casos diários
     df["daily_cases"] = df.groupby("city_id")["confirmed_cases"].diff(1)

--- a/src/loader/endpoints/get_cities_farolcovid_main.py
+++ b/src/loader/endpoints/get_cities_farolcovid_main.py
@@ -57,7 +57,10 @@ def _prepare_simulation(row, config):  # ok
     params = _calculate_recovered(row, params)
     dday_beds, _ = run_simulation(params, config)
 
-    return dday_beds["best"], dday_beds["worst"]
+    if row["subnotification_place_type"] == "state":
+        return np.nan, np.nan
+    else:
+        return dday_beds["best"], dday_beds["worst"]
 
 
 def get_indicators_capacity(df, config, rules, classify):  # ok

--- a/src/loader/endpoints/get_states_farolcovid_main.py
+++ b/src/loader/endpoints/get_states_farolcovid_main.py
@@ -1,0 +1,122 @@
+import pandas as pd
+import numpy as np
+import datetime as dt
+import yaml
+
+from endpoints import (
+    get_simulacovid_main,
+    get_cases,
+    get_states_rt,
+    get_inloco_states,
+)
+from endpoints.get_cities_farolcovid_main import (
+    get_indicators_subnotification,
+    get_indicators_rt,
+    get_indicators_inloco,
+    get_indicators_capacity,
+    get_overall_alert,
+)
+from endpoints.helpers import allow_local
+
+
+@allow_local
+def now(config):
+
+    config["farolcovid"] = yaml.load(
+        open("endpoints/aux/farol_config.yaml"), Loader=yaml.FullLoader
+    )
+
+    df = (
+        pd.read_csv(
+            "http://datasource.coronacidades.org:7000/br/cities/simulacovid/main"
+        )[config["farolcovid"]["simulacovid"]["columns"]]
+        .sort_values("state_id")
+        .groupby(["state_id", "state_name"])
+        .agg(config["farolcovid"]["simulacovid"]["state_agg"])
+        .rename({"state_notification_rate": "notification_rate"}, axis=1)
+        .assign(confirmed_cases=lambda x: x["confirmed_cases"].fillna(0))
+        .assign(deaths=lambda x: x["deaths"].fillna(0))
+        .assign(
+            number_beds=lambda x: config["farolcovid"]["resources"][
+                "available_proportion"
+            ]
+            * x["number_beds"]
+            / config["br"]["health"]["initial_proportion"]
+        )
+        .assign(
+            number_ventilators=lambda x: config["farolcovid"]["resources"][
+                "available_proportion"
+            ]
+            * x["number_ventilators"]
+            / config["br"]["health"]["initial_proportion"]
+        )
+        .reset_index()
+        .set_index("state_id")
+    )
+
+    # Calcula indicadores, classificações e crescimento
+    df = get_indicators_subnotification(
+        df,
+        data=get_cases.now(config),
+        place_id="state",
+        rules=config["farolcovid"]["rules"],
+        classify="subnotification_classification",
+    )
+
+    df = get_indicators_rt(
+        df,
+        data=get_states_rt.now(config),
+        place_id="state",
+        rules=config["farolcovid"]["rules"],
+        classify="rt_classification",
+        growth="rt_growth",
+    )
+
+    df = get_indicators_inloco(
+        df,
+        data=get_inloco_states.now(config),
+        place_id="state_id",
+        rules=config["farolcovid"]["rules"],
+        growth="inloco_growth",
+    )
+
+    df = get_indicators_capacity(
+        df, config, rules=config["farolcovid"]["rules"], classify="dday_classification"
+    )
+
+    df["overall_alert"] = df.apply(
+        lambda x: get_overall_alert(x, config["farolcovid"]["alerts"]), axis=1
+    ).replace("medio2", "medio")
+
+    return df.reset_index()
+
+
+TESTS = {
+    "more than 27 states": lambda df: len(df["state_id"].unique()) <= 27,
+    "df is not pd.DataFrame": lambda df: isinstance(df, pd.DataFrame),
+    "state doesnt have both rt classified and growth": lambda df: df[
+        "rt_classification"
+    ].count()
+    == df["rt_growth"].count(),
+    "dday worst greater than best": lambda df: len(
+        df[df["dday_beds_worst"] > df["dday_beds_best"]]
+    )
+    == 0,
+    "state with all classifications got null alert": lambda df: all(
+        df[df["overall_alert"].isnull()][
+            [
+                "rt_classification",
+                "rt_growth",
+                "dday_classification",
+                "subnotification_classification",
+            ]
+        ]
+        .isnull()
+        .apply(lambda x: any(x), axis=1)
+        == True
+    ),
+    "state without deaths has mortality ratio": lambda df: len(
+        df[(df["deaths"] == 0) & (~df["last_mortality_ratio"].isnull())]
+    )
+    == 0,
+}


### PR DESCRIPTION
- Fix cumulative deaths on `cases` table: it had some data 
- Generate FarolCovid data on `br/cities/simulacovid/main` & `br/states/simulacovid/main`

closes #13 