### PR TITLE
Safe reopen endpoints: Add health region + new state data url

### DIFF
--- a/src/loader/endpoints.yaml
+++ b/src/loader/endpoints.yaml
@@ -10,6 +10,10 @@
   python_file: get_states_safereopen_main
   skip: False
 
+- endpoint: br/health_region/safereopen/main
+  python_file: get_health_region_safereopen_main
+  skip: False
+
 - endpoint: br/cities/cases/full
   python_file: get_cases
   skip: False

--- a/src/loader/endpoints/get_health_region_safereopen_main.py
+++ b/src/loader/endpoints/get_health_region_safereopen_main.py
@@ -6,12 +6,14 @@ from numpy import dtype
 
 @allow_local
 def now(config, country="br"):
-
+    # TODO: add health_region_id
     return (
-        download_from_drive(config[country]["drive_paths"]["br_health_region_reopening_data"])
+        download_from_drive(
+            config[country]["drive_paths"]["br_health_region_reopening_data"]
+        )
         .rename(config["br"]["safereopen"]["rename"], axis=1)
         .assign(state_num_id=lambda df: df["state_num_id"].astype("int64"))
-        .assign(health_region=lambda df: df["health_region"].astype("int64"))
+        # .assign(health_region=lambda df: df["health_region_id"].astype("int64"))
         .assign(cnae=lambda df: df["cnae"].astype("int64"))
     )
 
@@ -22,8 +24,8 @@ TESTS = {
     "CNAE field is not exclusively ints": lambda df: df["cnae"].dtype == dtype("int64"),
     "UF field is not exclusively ints": lambda df: df["state_num_id"].dtype
     == dtype("int64"),
-    "health_region field is not exclusively ints": lambda df: df["health_region"].dtype
-    == dtype("int64"),
+    # "health_region field is not exclusively ints": lambda df: df["health_region"].dtype
+    # == dtype("int64"),
 }
 
 if __name__ == "__main__":

--- a/src/loader/endpoints/get_health_region_safereopen_main.py
+++ b/src/loader/endpoints/get_health_region_safereopen_main.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from utils import treat_text, download_from_drive
+from endpoints.helpers import allow_local
+from numpy import dtype
+
+
+@allow_local
+def now(config, country="br"):
+
+    return (
+        download_from_drive(config[country]["drive_paths"]["br_health_region_reopening_data"])
+        .rename(config["br"]["safereopen"]["rename"], axis=1)
+        .assign(state_num_id=lambda df: df["state_num_id"].astype("int64"))
+        .assign(health_region=lambda df: df["health_region"].astype("int64"))
+        .assign(cnae=lambda df: df["cnae"].astype("int64"))
+    )
+
+
+TESTS = {
+    "data is not pd.DataFrame": lambda df: isinstance(df, pd.DataFrame),
+    "data contains null datafield": lambda df: df.isnull().sum().sum() == 0,
+    "CNAE field is not exclusively ints": lambda df: df["cnae"].dtype == dtype("int64"),
+    "UF field is not exclusively ints": lambda df: df["state_num_id"].dtype
+    == dtype("int64"),
+    "health_region field is not exclusively ints": lambda df: df["health_region"].dtype
+    == dtype("int64"),
+}
+
+if __name__ == "__main__":
+    pass

--- a/src/loader/endpoints/get_states_safereopen_main.py
+++ b/src/loader/endpoints/get_states_safereopen_main.py
@@ -7,11 +7,8 @@ from numpy import dtype
 @allow_local
 def now(config, country="br"):
 
-    # TODO: change in config
-    config["br"]["safereopen"]["rename"]["uf"] = "state_num_id"
-
     return (
-        download_from_drive(config[country]["drive_paths"]["reopening_data"])
+        download_from_drive(config[country]["drive_paths"]["br_states_reopening_data"])
         .rename(config["br"]["safereopen"]["rename"], axis=1)
         .assign(state_num_id=lambda df: df["state_num_id"].astype("int64"))
         .assign(cnae=lambda df: df["cnae"].astype("int64"))

--- a/src/loader/endpoints/get_states_safereopen_main.py
+++ b/src/loader/endpoints/get_states_safereopen_main.py
@@ -11,7 +11,7 @@ def now(config, country="br"):
     config["br"]["safereopen"]["rename"]["uf"] = "state_num_id"
 
     return (
-        download_from_drive(config[country]["drive_paths"]["reopening_data"])
+        download_from_drive(config[country]["drive_paths"]["br_states_reopening_data"])
         .rename(config["br"]["safereopen"]["rename"], axis=1)
         .assign(state_num_id=lambda df: df["state_num_id"].astype("int64"))
         .assign(cnae=lambda df: df["cnae"].astype("int64"))


### PR DESCRIPTION
TODO: add `health_region_id` to the regional endpoint - only has `health_system_region` right now