### PR TITLE
Capacity update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,19 @@ server-run-shell: server-remove
 		-v "datasource:/output" \
 		$(SERVER_IMAGE_TAG)
 
+server-run-dev: server-remove
+	docker run -d --restart=unless-stopped \
+		--net=my-network \
+		--name datasource-server \
+		-p 7000:7000 \
+		-v "datasource:/output" \
+		$(SERVER_IMAGE_TAG)
+
+create-network:
+	docker network create -d bridge my-network
+
 # Groups
+server-dev: create-network server-build server-run-dev
 server-build-run: server-build server-run
 server-shell: server-build server-run-shell
 

--- a/loader.dockerfile
+++ b/loader.dockerfile
@@ -2,7 +2,7 @@ FROM tiangolo/uwsgi-nginx-flask:python3.7
 # TODO use another image without flask optimizations
 
 ENV OUTPUT_DIR="/output" \
-    CONFIG_URL="https://raw.githubusercontent.com/ImpulsoGov/farolcovid/stable/src/configs/config.yaml" \
+    CONFIG_URL="https://raw.githubusercontent.com/ImpulsoGov/farolcovid/capacity-update/src/configs/config.yaml" \
     IS_PROD="False" \
     SLACK_WEBHOOK="" \
     INLOCO_CITIES_KEY="" \

--- a/src/loader/endpoints/get_cities_farolcovid_main.py
+++ b/src/loader/endpoints/get_cities_farolcovid_main.py
@@ -75,13 +75,6 @@ def now(config):
         classify="trust_classification",
     )
 
-     # TODO: remover ao passar para branch no farol
-    config["br"]["farolcovid"]["rules"]["capacity_classification"] = {
-        "column_name": "number_icu_beds_100k",
-        "cuts": [0, 10, 20, 30, 1000000],
-        "categories": [3, 2, 1, 0],
-    }
-
     df = get_capacity_indicators(
         df,
         place_id="city_id",

--- a/src/loader/endpoints/get_cities_farolcovid_main.py
+++ b/src/loader/endpoints/get_cities_farolcovid_main.py
@@ -75,6 +75,13 @@ def now(config):
         classify="trust_classification",
     )
 
+     # TODO: remover ao passar para branch no farol
+    config["br"]["farolcovid"]["rules"]["capacity_classification"] = {
+        "column_name": "number_icu_beds_100k",
+        "cuts": [0, 10, 20, 30, 1000000],
+        "categories": [3, 2, 1, 0],
+    }
+
     df = get_capacity_indicators(
         df,
         place_id="city_id",

--- a/src/loader/endpoints/get_health_region_farolcovid_main.py
+++ b/src/loader/endpoints/get_health_region_farolcovid_main.py
@@ -223,6 +223,7 @@ def _prepare_simulation(row, place_id, config, place_specific_params, rt_upper=N
 
 def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
 
+    # TODO -> VOLTAR PROJECAO DE LEITOS
     # if place_id == "health_region_id":
     #     rt_upper = get_states_rt.now(config)
     #     place_specific_params = get_health_region_parameters.now(config).set_index(
@@ -244,6 +245,7 @@ def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
                         "number_beds",
                         "number_icu_beds",
                         "health_region_id",
+                        "population",
                     ]
                 ],
                 on="health_region_id",
@@ -252,8 +254,6 @@ def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
             .set_index("city_id")
         )
 
-        df = df.drop(columns=[col for col in df if "_drop" in col])
-
     # else:
     #     df["dday_icu_beds"] = df.apply(
     #         lambda row: _prepare_simulation(
@@ -261,11 +261,17 @@ def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
     #         ),
     #         axis=1,
     #     )
-
     # df["dday_icu_beds"] = df["dday_icu_beds"].replace(-1, 91)
 
     # Classificação: numero de dias para acabar a capacidade - MUDANÇA: leitos UTI por 100k
     df["number_icu_beds_100k"] = (10 ** 5) * (df["number_icu_beds"] / df["population"])
+
+    # Remove populacao da regional usada
+    if place_id == "city_id":
+        df = df.rename(
+            columns={"population": "population_drop", "population_drop": "population"}
+        )
+        df = df.drop(columns=[col for col in df if "_drop" in col])
 
     df[classify] = _get_levels(df, rules[classify])
 

--- a/src/loader/endpoints/get_health_region_farolcovid_main.py
+++ b/src/loader/endpoints/get_health_region_farolcovid_main.py
@@ -357,13 +357,6 @@ def now(config):
         classify="trust_classification",
     )
 
-    # TODO: remover ao passar para branch no farol
-    config["br"]["farolcovid"]["rules"]["capacity_classification"] = {
-        "column_name": "number_icu_beds_100k",
-        "cuts": [0, 10, 20, 30, 1000000],
-        "categories": [3, 2, 1, 0],
-    }
-
     df = get_capacity_indicators(
         df,
         place_id="health_region_id",

--- a/src/loader/endpoints/get_health_region_farolcovid_main.py
+++ b/src/loader/endpoints/get_health_region_farolcovid_main.py
@@ -223,15 +223,15 @@ def _prepare_simulation(row, place_id, config, place_specific_params, rt_upper=N
 
 def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
 
-    if place_id == "health_region_id":
-        rt_upper = get_states_rt.now(config)
-        place_specific_params = get_health_region_parameters.now(config).set_index(
-            place_id
-        )
+    # if place_id == "health_region_id":
+    #     rt_upper = get_states_rt.now(config)
+    #     place_specific_params = get_health_region_parameters.now(config).set_index(
+    #         place_id
+    #     )
 
-    if place_id == "state_num_id":
-        rt_upper = None
-        place_specific_params = get_states_parameters.now(config).set_index(place_id)
+    # if place_id == "state_num_id":
+    #     rt_upper = None
+    #     place_specific_params = get_states_parameters.now(config).set_index(place_id)
 
     # Pega valores calculados para regional e soma total de leitos
     if place_id == "city_id":
@@ -240,7 +240,7 @@ def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
             .merge(
                 data[
                     [
-                        "dday_icu_beds",
+                        # "dday_icu_beds",
                         "number_beds",
                         "number_icu_beds",
                         "health_region_id",
@@ -252,21 +252,21 @@ def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
             .set_index("city_id")
         )
 
-        df[classify] = _get_levels(df, rules[classify])
-        return df.drop(columns=[col for col in df if "_drop" in col])
+        df = df.drop(columns=[col for col in df if "_drop" in col])
 
-    else:
-        df["dday_icu_beds"] = df.apply(
-            lambda row: _prepare_simulation(
-                row, place_id, config, place_specific_params, rt_upper
-            ),
-            axis=1,
-        )
+    # else:
+    #     df["dday_icu_beds"] = df.apply(
+    #         lambda row: _prepare_simulation(
+    #             row, place_id, config, place_specific_params, rt_upper
+    #         ),
+    #         axis=1,
+    #     )
 
-    df["dday_icu_beds"] = df["dday_icu_beds"].replace(-1, 91)
+    # df["dday_icu_beds"] = df["dday_icu_beds"].replace(-1, 91)
 
-    rules[classify]
-    # Classificação: numero de dias para acabar a capacidade
+    # Classificação: numero de dias para acabar a capacidade - MUDANÇA: leitos UTI por 100k
+    df["number_icu_beds_100k"] = (10 ** 5) * (df["number_icu_beds"] / df["population"])
+
     df[classify] = _get_levels(df, rules[classify])
 
     return df
@@ -327,7 +327,6 @@ def now(config):
         .set_index("health_region_id")
     )
 
-    # TODO: get_cases => get_states_cases / mudar indicadores de situacao + add trust (notification_rate)!
     df = get_situation_indicators(
         df,
         data=get_health_region_cases.now(config),
@@ -351,6 +350,13 @@ def now(config):
         rules=config["br"]["farolcovid"]["rules"],
         classify="trust_classification",
     )
+
+    # TODO: remover ao passar para branch no farol
+    config["br"]["farolcovid"]["rules"]["capacity_classification"] = {
+        "column_name": "number_icu_beds_100k",
+        "cuts": [0, 10, 20, 30, 1000000],
+        "categories": [3, 2, 1, 0],
+    }
 
     df = get_capacity_indicators(
         df,

--- a/src/loader/endpoints/get_states_farolcovid_main.py
+++ b/src/loader/endpoints/get_states_farolcovid_main.py
@@ -105,6 +105,13 @@ def now(config):
         classify="trust_classification",
     )
 
+     # TODO: remover ao passar para branch no farol
+    config["br"]["farolcovid"]["rules"]["capacity_classification"] = {
+        "column_name": "number_icu_beds_100k",
+        "cuts": [0, 10, 20, 30, 1000000],
+        "categories": [3, 2, 1, 0],
+    }
+
     df = get_capacity_indicators(
         df,
         place_id="state_num_id",

--- a/src/loader/endpoints/get_states_farolcovid_main.py
+++ b/src/loader/endpoints/get_states_farolcovid_main.py
@@ -105,13 +105,6 @@ def now(config):
         classify="trust_classification",
     )
 
-     # TODO: remover ao passar para branch no farol
-    config["br"]["farolcovid"]["rules"]["capacity_classification"] = {
-        "column_name": "number_icu_beds_100k",
-        "cuts": [0, 10, 20, 30, 1000000],
-        "categories": [3, 2, 1, 0],
-    }
-
     df = get_capacity_indicators(
         df,
         place_id="state_num_id",
@@ -129,7 +122,7 @@ def now(config):
 
     df["overall_alert"] = df.apply(
         lambda row: get_overall_alert(row[cols]), axis=1
-    ) # .replace(config["br"]["farolcovid"]["categories"])
+    )  # .replace(config["br"]["farolcovid"]["categories"])
 
     return df.reset_index()
 


### PR DESCRIPTION
Muda indicador de capacidade hospitalar: substituímos por ora a projeção de leitos por número de leitos UTI por 100mil habitantes

TODO:
- [x] Passar mudanças de valor de referência para `config` no farol
- [ ] Mudar `config` para stable depois de subir no farol

Extra:
- Adicionei no Makefile a opção de rodar a API e farol local com `make-server-dev`: essa opção cria uma rede `my-network` para rodar o container e a mesma rede deve ser utilizada para rodar o farol local com a API, pois `localhost` não funciona - ver mudanças no [Makefile do farol](https://github.com/ImpulsoGov/farolcovid/pull/228).