### PR TITLE
Adiciona ocupação de UTIs

### DIFF
--- a/src/loader/endpoints.yaml
+++ b/src/loader/endpoints.yaml
@@ -73,6 +73,10 @@
   python_file: get_cities_rt
   skip: False
 
+- endpoint: br/states/beds_occupation
+  python_file: get_states_beds_occupation
+  skip: False
+
 - endpoint: br/health_region/farolcovid/main
   python_file: get_health_region_farolcovid_main
   skip: False

--- a/src/loader/endpoints/get_health_region_farolcovid_main.py
+++ b/src/loader/endpoints/get_health_region_farolcovid_main.py
@@ -1,376 +1,23 @@
 import pandas as pd
-import numpy as np
-import datetime as dt
-import yaml
-from pathlib import Path
 
-from endpoints import (
-    get_health_region_cases,
-    get_health_region_rt,
-    get_states_rt,
-    get_cnes,
-    get_health_region_parameters,
-    get_states_parameters,
-)
-
+from endpoints import get_health_region_cases, get_health_region_rt
+from endpoints.get_indicators import get_place_indicators
 from endpoints.helpers import allow_local
-from endpoints.scripts.simulator import run_simulation
-
-
-def _get_levels(df, rules):
-    return pd.cut(
-        df[rules["column_name"]],
-        bins=rules["cuts"],
-        labels=rules["categories"],
-        right=False,
-        include_lowest=True,
-    )
-
-
-# SITUATION: New cases
-def _get_growth_ndays(group, place_id):
-    """Calculate how many days the group is on the last growth status
-    """
-    group = group.reset_index()[[place_id, "daily_cases_growth"]].drop_duplicates(
-        keep="last"
-    )
-    # if only had one status since the beginning
-    if len(group) == 1:
-        group["daily_cases_growth_ndays"] = group.index[-1]
-    else:
-        group["daily_cases_growth_ndays"] = group.index[-1] - group.index[-2]
-
-    return group.tail(1)
-
-
-def get_situation_indicators(df, data, place_id, rules, classify):
-
-    data["last_updated"] = pd.to_datetime(data["last_updated"])
-
-    # Get ndays of last growth status
-    df["daily_cases_growth_ndays"] = (
-        data.sort_values(by=[place_id, "last_updated"])
-        .groupby(place_id)
-        .apply(lambda group: _get_growth_ndays(group, place_id))
-        .reset_index(drop=True)
-        .set_index(place_id)
-    )["daily_cases_growth_ndays"]
-
-    data = data.loc[data.groupby(place_id)["last_updated"].idxmax()].set_index(place_id)
-    df["last_updated_cases"] = data["last_updated"]
-
-    # Get indicators & update cases and deaths to current date
-    cols = [
-        "confirmed_cases",
-        "daily_cases",
-        "deaths",
-        "new_deaths",
-        "daily_cases_mavg_100k",
-        "daily_cases_growth",
-        "new_deaths_mavg_100k",
-        "new_deaths_growth",
-    ]
-    df[cols] = data[cols]
-
-    df[classify] = _get_levels(df, rules[classify])
-    df[classify] = df.apply(
-        lambda row: row[classify] + 1
-        if (row["daily_cases_growth"] == "crescendo" and row[classify] < 3)
-        else row[classify],
-        axis=1,
-    )
-
-    return df
-
-
-# CONTROL: - (no testing data!)
-def get_control_indicators(
-    df, data, place_id, rules, classify, config=None, region_data=None
-):
-    data = data.assign(last_updated=lambda df: pd.to_datetime(df["last_updated"]))
-
-    # Min-max do Rt de 14 dias (max data de taxa de notificacao) -> 10 dias atrás (KEVIN & COVIDACTNOW)
-    data = data.loc[data.groupby(place_id)["last_updated"].idxmax()]
-
-    rename = {
-        i: i.lower()
-        for i in ["Rt_low_95", "Rt_high_95", "Rt_most_likely", "Rt_most_likely_growth"]
-    }
-    rename["last_updated"] = "last_updated_rt"
-
-    df[list(rename.values())] = data.sort_values(place_id).set_index(place_id)[
-        list(rename.keys())
-    ]
-
-    # Completa com Rt da regional
-    if place_id == "city_id":
-
-        df["rt_place_type"] = (
-            df["rt_most_likely"]
-            .isnull()
-            .map({True: "health_region_id", False: "city_id"})
-        )
-
-        # add city_id
-        data = (
-            df[["health_region_id"]]
-            .reset_index()
-            .merge(region_data, on="health_region_id")
-            .set_index("city_id")
-        )
-
-        rename["health_region_id"] = "health_region_id"
-
-        df.loc[df["rt_place_type"] == "health_region_id", list(rename.values())] = data[
-            list(rename.values())
-        ]
-        df["last_updated_rt"] = pd.to_datetime(df["last_updated_rt"])
-
-    # Classificação: melhor estimativa do Rt de 10 dias (rt_most_likely)
-    df[classify] = _get_levels(df, rules[classify])
-
-    return df
-
-
-# CAPACITY
-def _calculate_recovered(df, params):
-
-    confirmed_adjusted = int(df[["confirmed_cases"]].sum() / df["notification_rate"])
-
-    if confirmed_adjusted == 0:  # dont have any cases yet
-        params["population_params"]["R"] = 0
-        return params
-
-    params["population_params"]["R"] = (
-        confirmed_adjusted
-        - params["population_params"]["I"]
-        - params["population_params"]["D"]
-    )
-
-    if params["population_params"]["R"] < 0:
-        params["population_params"]["R"] = (
-            confirmed_adjusted - params["population_params"]["D"]
-        )
-
-    return params
-
-
-# TODO: rever para colocar num script a parte!
-def _prepare_simulation(row, place_id, config, place_specific_params, rt_upper=None):
-
-    # based on Alison Hill: 40% asymptomatic
-    symtomatic = [
-        int(
-            row["active_cases"]
-            * (1 - config["br"]["seir_parameters"]["asymptomatic_proportion"])
-        )
-        if not np.isnan(row["active_cases"])
-        else 1
-    ][0]
-
-    params = {
-        "population_params": {
-            "N": int(row["population"]),
-            "I": symtomatic,
-            "D": [int(row["deaths"]) if not np.isnan(row["deaths"]) else 0][0],
-        },
-        "place_specific_params": {
-            "fatality_ratio": place_specific_params["fatality_ratio"].loc[
-                int(row.name)
-            ],
-            "i1_percentage": place_specific_params["i1_percentage"].loc[int(row.name)],
-            "i2_percentage": place_specific_params["i2_percentage"].loc[int(row.name)],
-            "i3_percentage": place_specific_params["i3_percentage"].loc[int(row.name)],
-        },
-        "n_beds": row["number_beds"]
-        * config["br"]["simulacovid"]["resources_available_proportion"],
-        "n_icu_beds": row["number_icu_beds"]
-        * config["br"]["simulacovid"]["resources_available_proportion"],
-        "R0": {
-            "best": row["rt_most_likely"],  # só usamos o "best" neste caso
-            "worst": row["rt_high_95"],
-        },
-    }
-
-    # TODO: checar esses casos no calculo da subnotificacao!
-    if row["notification_rate"] != row["notification_rate"]:
-        return np.nan
-
-    if row["notification_rate"] == 0:
-        return np.nan
-
-    # TODO: precisa? Seleciona rt de 1 nivel acima caso não tenha
-    if row["rt_most_likely"] != row["rt_most_likely"]:
-        if place_id == "health_region_id":
-            rt = rt_upper.query(f"state_num_id == {row['state_num_id']}")
-        else:
-            return np.nan
-
-        if len(rt) > 0:
-            rt = rt.assign(
-                last_updated=lambda df: pd.to_datetime(df["last_updated"])
-            ).query("last_updated == last_updated.max()")
-            params["R0"] = {"best": rt["Rt_most_likely"], "worst": rt["Rt_high_95"]}
-        else:
-            return np.nan
-
-    params = _calculate_recovered(row, params)
-
-    # Run simulation
-    dday = run_simulation(params, config)
-    return dday["beds"]["best"]
-
-
-def get_capacity_indicators(df, place_id, config, rules, classify, data=None):
-
-    # TODO -> VOLTAR PROJECAO DE LEITOS
-    # if place_id == "health_region_id":
-    #     rt_upper = get_states_rt.now(config)
-    #     place_specific_params = get_health_region_parameters.now(config).set_index(
-    #         place_id
-    #     )
-
-    # if place_id == "state_num_id":
-    #     rt_upper = None
-    #     place_specific_params = get_states_parameters.now(config).set_index(place_id)
-
-    # Pega valores calculados para regional e soma total de leitos
-    if place_id == "city_id":
-        df = (
-            df.reset_index()
-            .merge(
-                data[
-                    [
-                        # "dday_icu_beds",
-                        "number_beds",
-                        "number_icu_beds",
-                        "health_region_id",
-                        "population",
-                    ]
-                ],
-                on="health_region_id",
-                suffixes=("_drop", ""),
-            )
-            .set_index("city_id")
-        )
-
-    # else:
-    #     df["dday_icu_beds"] = df.apply(
-    #         lambda row: _prepare_simulation(
-    #             row, place_id, config, place_specific_params, rt_upper
-    #         ),
-    #         axis=1,
-    #     )
-    # df["dday_icu_beds"] = df["dday_icu_beds"].replace(-1, 91)
-
-    # Classificação: numero de dias para acabar a capacidade - MUDANÇA: leitos UTI por 100k
-    df["number_icu_beds_100k"] = (10 ** 5) * (df["number_icu_beds"] / df["population"])
-
-    # Remove populacao da regional usada
-    if place_id == "city_id":
-        df = df.rename(
-            columns={"population": "population_drop", "population_drop": "population"}
-        )
-        df = df.drop(columns=[col for col in df if "_drop" in col])
-
-    df[classify] = _get_levels(df, rules[classify])
-
-    return df
-
-
-# TRUST
-# TODO: add here after update on cases df
-def get_trust_indicators(df, data, place_id, rules, classify):
-
-    data["last_updated"] = pd.to_datetime(data["last_updated"])
-
-    # Última data com notificação: 14 dias atrás
-    df[["last_updated_subnotification", "notification_rate", "active_cases"]] = (
-        data.dropna()
-        .groupby(place_id)[["last_updated", "notification_rate", "active_cases"]]
-        .last()
-    )
-
-    df["subnotification_rate"] = 1 - df["notification_rate"]
-
-    # Classificação: percentual de subnotificação
-    df[classify] = _get_levels(df, rules[classify])
-
-    return df
-
-
-def get_overall_alert(indicators):
-    if indicators.notnull().all():
-        return int(max(indicators))
-    else:
-        return np.nan
 
 
 @allow_local
 def now(config):
 
     # Get resource data
-    df = (
-        get_cnes.now(config)
-        .groupby(
-            [
-                "country_iso",
-                "country_name",
-                "state_num_id",
-                "state_id",
-                "state_name",
-                "health_region_id",
-                "health_region_name",
-                "last_updated_number_beds",
-                "author_number_beds",
-                "last_updated_number_icu_beds",
-                "author_number_icu_beds",
-            ]
-        )
-        .agg({"population": sum, "number_beds": sum, "number_icu_beds": sum})
-        .reset_index()
-        .sort_values("health_region_id")
-        .set_index("health_region_id")
-    )
+    data_cases = get_health_region_cases.now(config)
+    data_rt = get_health_region_rt.now(config)
 
-    df = get_situation_indicators(
-        df,
-        data=get_health_region_cases.now(config),
+    return get_place_indicators(
         place_id="health_region_id",
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="situation_classification",
-    )
-
-    df = get_control_indicators(
-        df,
-        data=get_health_region_rt.now(config),
-        place_id="health_region_id",
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="control_classification",
-    )
-
-    df = get_trust_indicators(
-        df,
-        data=get_health_region_cases.now(config),
-        place_id="health_region_id",
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="trust_classification",
-    )
-
-    df = get_capacity_indicators(
-        df,
-        place_id="health_region_id",
+        data_cases=data_cases,
+        data_rt=data_rt,
         config=config,
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="capacity_classification",
     )
-
-    cols = [col for col in df.columns if "classification" in col]
-    df["overall_alert"] = df.apply(
-        lambda row: get_overall_alert(row[cols]), axis=1
-    )  # .replace(config["br"]["farolcovid"]["categories"])
-
-    return df.reset_index()
 
 
 TESTS = {
@@ -378,7 +25,9 @@ TESTS = {
     "overall alert > 3": lambda df: all(
         df[~df["overall_alert"].isnull()]["overall_alert"] <= 3
     ),
-    "doesnt have 450 regions": lambda df: len(df["health_region_id"].unique()) == 450,
+    "doesnt have 450 regions": lambda df: len(
+        df["health_region_id"].unique()
+    ) == 450,
     "df is not pd.DataFrame": lambda df: isinstance(df, pd.DataFrame),
     # "dataframe has null data": lambda df: all(df.isnull().any() == False),
     "doesnt have both rt classified and growth": lambda df: df[
@@ -396,7 +45,6 @@ TESTS = {
         ]
         .isnull()
         .apply(lambda x: any(x), axis=1)
-        == True
     ),
     "region without classification got an alert": lambda df: all(
         df[
@@ -411,6 +59,5 @@ TESTS = {
             .isnull()
             .any(axis=1)
         ]["overall_alert"].isnull()
-        == True
     ),
 }

--- a/src/loader/endpoints/get_indicators.py
+++ b/src/loader/endpoints/get_indicators.py
@@ -1,0 +1,303 @@
+import pandas as pd
+import numpy as np
+
+from endpoints import (
+    get_states_beds_occupation,
+    get_cnes,
+)
+from logger import logger
+
+
+def _get_levels(df, rules):
+    return pd.cut(
+        df[rules["column_name"]],
+        bins=rules["cuts"],
+        labels=rules["categories"],
+        right=False,
+        include_lowest=True,
+    )
+
+
+# SITUATION: New cases
+def _get_growth_ndays(group, place_id):
+    """Calculate how many days the group is on the last growth status"""
+    group = group.reset_index()[
+        [place_id, "daily_cases_growth"]
+    ].drop_duplicates(keep="last")
+    # if only had one status since the beginning
+    if len(group) == 1:
+        group["daily_cases_growth_ndays"] = group.index[-1]
+    else:
+        group["daily_cases_growth_ndays"] = group.index[-1] - group.index[-2]
+
+    return group.tail(1)
+
+
+def get_situation_indicators(df, data, place_id, rules, classify):
+    logger.info("Consolidating situation indicators on '{}'".format(place_id))
+    data["last_updated"] = pd.to_datetime(data["last_updated"])
+
+    # Get ndays of last growth status
+    df["daily_cases_growth_ndays"] = (
+        data.sort_values(by=[place_id, "last_updated"])
+        .groupby(place_id)
+        .apply(lambda group: _get_growth_ndays(group, place_id))
+        .reset_index(drop=True)
+        .set_index(place_id)
+    )["daily_cases_growth_ndays"]
+
+    data = data.loc[data.groupby(place_id)["last_updated"].idxmax()].set_index(
+        place_id
+    )
+    df["last_updated_cases"] = data["last_updated"]
+
+    # Get indicators & update cases and deaths to current date
+    cols = [
+        "confirmed_cases",
+        "daily_cases",
+        "deaths",
+        "new_deaths",
+        "daily_cases_mavg_100k",
+        "daily_cases_growth",
+        "new_deaths_mavg_100k",
+        "new_deaths_growth",
+    ]
+    df[cols] = data[cols]
+
+    df[classify] = _get_levels(df, rules[classify])
+    df[classify] = df.apply(
+        lambda row: row[classify] + 1
+        if (row["daily_cases_growth"] == "crescendo" and row[classify] < 3)
+        else row[classify],
+        axis=1,
+    )
+
+    return df
+
+
+# CONTROL: - (no testing data!)
+def get_control_indicators(
+    df, data, place_id, rules, classify, region_data=None,
+):
+    logger.info("Consolidating control indicators on '{}'".format(place_id))
+
+    rename = {
+        i: i.lower()
+        for i in [
+            "Rt_low_95",
+            "Rt_high_95",
+            "Rt_most_likely",
+            "Rt_most_likely_growth",
+        ]
+    }
+    rename["last_updated"] = "last_updated_rt"
+
+    data = data.astype({"last_updated": "datetime64"}).rename(columns=rename)
+
+    # Min-max do Rt de 14 dias (max data de taxa de notificacao) -> 10 dias
+    # atrás (KEVIN & COVIDACTNOW)
+    data = data.loc[data.groupby(place_id)["last_updated_rt"].idxmax(), :]
+
+    df = (
+        df
+        .merge(data, suffixes=("", "_drop"), on=place_id, how="left")
+        .reset_index()
+    )
+    df = df.drop(columns=[col for col in df.columns if "_drop" in col])
+
+    # Completa com Rt da regional
+    if place_id == "city_id":
+
+        region_data = (
+            region_data
+            .astype({"last_updated": "datetime64"})
+            .rename(columns=rename)
+        )
+        region_data = region_data.loc[
+            region_data
+            .groupby("health_region_id")["last_updated_rt"]
+            .idxmax(),
+            :
+        ]
+
+        df["rt_place_type"] = (
+            df["rt_most_likely"]
+            .isnull()
+            .map({True: "health_region_id", False: "city_id"})
+        )
+        df_city_rt = df.loc[df["rt_place_type"] == "city_id", :]
+        df_region_rt = df.loc[df["rt_place_type"] == "health_region_id", :]
+
+        df_city_rt = (
+            df_city_rt
+            .merge(
+                region_data,
+                suffixes=("_drop", ""),
+                on="health_region_id",
+                how="left",
+            )
+            .reset_index()
+        )
+        df_city_rt = df_city_rt.drop(
+            columns=[col for col in df_city_rt.columns if "_drop" in col]
+        )
+
+        df = pd.concat([df_city_rt, df_region_rt], ignore_index=True)
+
+    # Classificação: melhor estimativa do Rt de 10 dias (rt_most_likely)
+    df[classify] = _get_levels(df, rules[classify])
+
+    return df
+
+
+# TRUST
+# TODO: add here after update on cases df
+def get_trust_indicators(df, data, place_id, rules, classify):
+    logger.info("Consolidating trust indicators on '{}'".format(place_id))
+
+    data["last_updated"] = pd.to_datetime(data["last_updated"])
+
+    # Última data com notificação: 14 dias atrás
+    df[
+        ["last_updated_subnotification", "notification_rate", "active_cases"]
+    ] = (
+        data.dropna()
+        .groupby(place_id)[
+            ["last_updated", "notification_rate", "active_cases"]
+        ]
+        .last()
+    )
+
+    df["subnotification_rate"] = 1 - df["notification_rate"]
+
+    # Classificação: percentual de subnotificação
+    df[classify] = _get_levels(df, rules[classify])
+
+    return df
+
+
+def get_capacity_indicators(df, config, rules, classify):
+    logger.info("Consolidating capacity indicators")
+
+    # agregar leitos por estado (não faz diferença se `df` já for por estado)
+    capacity_state = (
+        df.groupby(
+            [
+                "state_num_id",
+                "last_updated_number_beds",
+                "author_number_beds",
+                "last_updated_number_icu_beds",
+                "author_number_icu_beds",
+            ]
+        )[["population", "number_beds", "number_icu_beds"]]
+        .sum()
+        .reset_index()
+    )
+
+    # Leitos UTI e enfermaria por 100k habitantes
+    df["number_beds_100k"] = (10 ** 5) * (df["number_beds"] / df["population"])
+    df["number_icu_beds_100k"] = (10 ** 5) * (
+        df["number_icu_beds"] / df["population"]
+    )
+
+    # ocupação em UTIs no estado
+    occupation = (
+        get_states_beds_occupation
+        .now(config)
+        .astype({"last_updated": "datetime64"})
+        .rename(columns={"last_updated": "last_updated_icu_occupation"})
+    )
+    occupation_latest = occupation.loc[
+        occupation
+        .groupby("state_num_id")["last_updated_icu_occupation"]
+        .idxmax(),
+        :
+    ]
+    capacity_state = capacity_state.merge(
+        occupation_latest, on="state_num_id", suffixes=("", "_drop")
+    ).reset_index()
+
+    # Juntar ao DataFrame original
+    df = df.merge(
+        capacity_state, on="state_num_id", suffixes=("", "_drop")
+    )
+
+    # remove colunas duplicadas
+    df = df.drop(columns=[col for col in df if "_drop" in col])
+
+    df[classify] = _get_levels(df, rules[classify])
+
+    return df
+
+
+def get_overall_alert(indicators):
+    if indicators.notnull().all():
+        return int(max(indicators))
+    else:
+        return np.nan
+
+
+def get_place_indicators(
+    place_id, data_cases, data_rt, config, data_rt_region=None
+):
+    cnes_cols = [
+        "country_iso",
+        "country_name",
+        "state_num_id",
+        "state_id",
+        "state_name",
+        "last_updated_number_beds",
+        "author_number_beds",
+        "last_updated_number_icu_beds",
+        "author_number_icu_beds",
+    ]
+    if place_id == "health_region_id" or place_id == "city_id":
+        cnes_cols += ["health_region_id", "health_region_name"]
+    if place_id == "city_id":
+        cnes_cols += ["city_id", "city_name"]
+
+    rules = config["br"]["farolcovid"]["rules"]
+
+    df = (
+        get_cnes.now(config)
+        .groupby(cnes_cols)
+        .agg({"population": sum, "number_beds": sum, "number_icu_beds": sum})
+        .reset_index()
+        .set_index(place_id)
+        .sort_index()
+        .pipe(
+            get_situation_indicators,
+            data=data_cases,
+            place_id=place_id,
+            rules=rules,
+            classify="situation_classification",
+        )
+        .pipe(
+            get_control_indicators,
+            data=data_rt,
+            place_id=place_id,
+            rules=rules,
+            classify="control_classification",
+            region_data=data_rt_region,
+        )
+        .pipe(
+            get_trust_indicators,
+            data=data_cases,
+            place_id=place_id,
+            rules=rules,
+            classify="trust_classification",
+        )
+        .pipe(
+            get_capacity_indicators,
+            rules=rules,
+            classify="capacity_classification",
+            config=config,
+        )
+    )
+
+    classif_cols = [col for col in df.columns if "classification" in col]
+    df["overall_alert"] = df.apply(
+        lambda row: get_overall_alert(row[classif_cols]), axis=1
+    )
+
+    return df

--- a/src/loader/endpoints/get_states_beds_occupation.py
+++ b/src/loader/endpoints/get_states_beds_occupation.py
@@ -1,0 +1,97 @@
+from urllib.error import HTTPError
+
+import pandas as pd
+
+from endpoints.helpers import allow_local
+from logger import logger
+
+
+UF = [
+    "Acre",
+    "Alagoas",
+    "Amapá",
+    "Amazonas",
+    "Bahia",
+    "Ceará",
+    "Distrito Federal",
+    "Espírito Santo",
+    "Goiás",
+    "Maranhão",
+    "Mato Grosso",
+    "Mato Grosso do Sul",
+    "Minas Gerais",
+    "Pará",
+    "Paraíba",
+    "Paraná",
+    "Pernambuco",
+    "Piauí",
+    "Rio de Janeiro",
+    "Rio Grande do Norte",
+    "Rio Grande do Sul",
+    "Rondônia",
+    "Roraima",
+    "Santa Catarina",
+    "São Paulo",
+    "Sergipe",
+    "Tocantins",
+]
+
+
+def download_giscard_tables():
+    """Fetches data from Giscard's 'Painel COVID-19'."""
+    giscard = pd.DataFrame()
+
+    for ix, uf in enumerate(UF):
+        for attempt in range(1, 3):
+            try:
+                giscard_uf = pd.read_csv(
+                    "http://www.giscard.com.br/coronavirus/arquivos"
+                    + "/painel-covid19-giscard-{}.csv".format(ix + 1001),
+                    parse_dates=["Data Casos"],
+                    dayfirst=True,
+                    usecols=["Data Casos", "Ocupacao Leitos UTI"],
+                )
+            except HTTPError:
+                continue
+            else:
+                giscard_uf["state_name"] = uf
+                giscard_uf["author_icu_occupation"] = "Giscard"
+                giscard = pd.concat([giscard, giscard_uf], ignore_index=True)
+                break
+
+    return (
+        giscard
+        .replace(0, pd.NA)
+        .rename(columns={
+            "Data Casos": "last_updated",
+            "Ocupacao Leitos UTI": "icu_occupation_rate",
+        })
+    )
+
+
+@allow_local
+def now(config):
+    logger.info("Baixando dados de ocupação hospitalar")
+    places_ids = pd.read_csv(
+            "http://datasource.coronacidades.org/br/places/ids",
+            usecols=["state_id", "state_name", "state_num_id"],
+    ).drop_duplicates()
+    df_occupation = download_giscard_tables()
+    return places_ids.merge(df_occupation, on="state_name")
+
+
+TESTS = {
+    "df is not pd.DataFrame": lambda df: isinstance(df, pd.DataFrame),
+    "doesnt have 27 states": lambda df: len(df["state_num_id"].unique()) == 27,
+    "duplicated state and date": (
+        lambda df: df.duplicated(["state_num_id", "last_updated"]).sum() == 0
+    ),
+    "missing required fields": (
+        lambda df: df[[
+            "state_name",
+            "state_id",
+            "state_num_id",
+            "last_updated",
+        ]].notnull().values.all()
+    )
+}

--- a/src/loader/endpoints/get_states_farolcovid_main.py
+++ b/src/loader/endpoints/get_states_farolcovid_main.py
@@ -1,130 +1,23 @@
 import pandas as pd
-import numpy as np
-import datetime as dt
-import yaml
-from math import ceil
 
-from endpoints import (
-    get_states_cases,
-    get_states_rt,
-    get_cnes,
-    get_health_region_farolcovid_main,
-)
-from endpoints.get_cities_farolcovid_main import (
-    get_situation_indicators,
-    get_control_indicators,
-    get_capacity_indicators,
-    get_trust_indicators,
-    get_overall_alert,
-)
+from endpoints import get_states_cases, get_states_rt
+from endpoints.get_indicators import get_place_indicators
 from endpoints.helpers import allow_local
-
-
-def _get_weighted_level(df_regions):
-
-    # Get max alert of at least half regions
-    max_regions_alert = (
-        df_regions.dropna(subset=["overall_alert"])
-        .groupby("state_num_id")["overall_alert"]
-        .apply(lambda x: ceil(np.quantile(x, 0.5)))
-    )
-
-    # Get state cumulative population by alert
-    max_pop_alert = (
-        df_regions.groupby(["state_num_id", "overall_alert"])["population"]
-        .sum()
-        .groupby(level=0)
-        .cumsum()
-        .reset_index()
-    )
-
-    # Compare to state population mean and get max alert of at least half population
-    max_pop_alert = (
-        max_pop_alert.merge(
-            max_pop_alert.groupby("state_num_id")["population"].apply(
-                lambda x: max(x) / 2
-            ),
-            on="state_num_id",
-            suffixes=("", "_mean"),
-        )
-        .query("population >= population_mean")
-        .drop_duplicates(subset=["state_num_id"], keep="first")
-        .set_index("state_num_id")["overall_alert"]
-    )
-
-    # Get max overall alert between population and regions POV
-    return pd.concat([max_pop_alert, max_regions_alert], axis=1).max(axis=1)
 
 
 @allow_local
 def now(config):
 
     # Get resource data
-    df = (
-        get_cnes.now(config)
-        .groupby(
-            [
-                "country_iso",
-                "country_name",
-                "state_num_id",
-                "state_id",
-                "state_name",
-                "last_updated_number_beds",
-                "author_number_beds",
-                "last_updated_number_icu_beds",
-                "author_number_icu_beds",
-            ]
-        )
-        .agg({"population": sum, "number_beds": sum, "number_icu_beds": sum})
-        .reset_index()
-        .sort_values("state_num_id")
-        .set_index("state_num_id")
-    )
+    data_cases = get_states_cases.now(config)
+    data_rt = get_states_rt.now(config)
 
-    df = get_situation_indicators(
-        df,
-        data=get_states_cases.now(config),
+    return get_place_indicators(
         place_id="state_num_id",
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="situation_classification",
-    )
-
-    df = get_control_indicators(
-        df,
-        data=get_states_rt.now(config),
-        place_id="state_num_id",
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="control_classification",
-    )
-
-    df = get_trust_indicators(
-        df,
-        data=get_states_cases.now(config),
-        place_id="state_num_id",
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="trust_classification",
-    )
-
-    df = get_capacity_indicators(
-        df,
-        place_id="state_num_id",
+        data_cases=data_cases,
+        data_rt=data_rt,
         config=config,
-        rules=config["br"]["farolcovid"]["rules"],
-        classify="capacity_classification",
     )
-
-    cols = [col for col in df.columns if "classification" in col]
-
-    # TODO: Overall alert - max of cumulative regions in level
-    # df["overall_alert"] = _get_weighted_level(
-    #     get_health_region_farolcovid_main.now(config)
-    # )
-
-    df["overall_alert"] = df.apply(
-        lambda row: get_overall_alert(row[cols]), axis=1
-    )  # .replace(config["br"]["farolcovid"]["categories"])
-
-    return df.reset_index()
 
 
 TESTS = {
@@ -157,7 +50,6 @@ TESTS = {
         ]
         .isnull()
         .apply(lambda x: any(x), axis=1)
-        == True
     ),
     # "state without classification got an alert": lambda df: all(
     #     df[


### PR DESCRIPTION
Obtém os dados de ocupação hospitalar em UTIs do Painel COVID-19.

Além disso, refatora a consolidação de indicadores do FarolCovid, evitando importações circulares.